### PR TITLE
Fix typos + add missing links

### DIFF
--- a/slides/sections/101-dockerfiles-and-images.md
+++ b/slides/sections/101-dockerfiles-and-images.md
@@ -86,7 +86,7 @@ for ($i=0; $i -lt 5; $i++) {
 
 ## Check all the containers
 
-You now have multiple instances of the app running. The Docker image is the same, but each instance will show its own containr ID.
+You now have multiple instances of the app running. The Docker image is the same, but each instance will show its own container ID.
 
 _ Browse to all the new containers:_
 

--- a/slides/sections/frontend-web.md
+++ b/slides/sections/frontend-web.md
@@ -29,7 +29,7 @@ docker image build -t dwwx/signup-web `
 
 ## Build a better image
 
-The v1 Dockerfile is simple, but inefficient. The [v2 Dockerfile](./docker/frontend-web/v2/Dockerfile) splits the NuGet restore and MSBuild parts - which makes repeated builds faser. And it relays the application log file.
+The v1 Dockerfile is simple, but inefficient. The [v2 Dockerfile](./docker/frontend-web/v2/Dockerfile) splits the NuGet restore and MSBuild parts - which makes repeated builds faster. And it relays the application log file.
 
 _Build the image:_
 

--- a/slides/sections/metrics-application.md
+++ b/slides/sections/metrics-application.md
@@ -14,7 +14,7 @@ The message handlers already have code to record metrics when they handle messag
 
 You can see this in the [Program.cs](./src/SignUp.MessageHandlers.SaveProspect/Program.cs) file for the SQL Server handler, and the [QueueWorker.cs](./src/SignUp.MessageHandlers.IndexProspect/Workers/QueueWorker.cs) file for the Elasticsearch handler.
 
-> Both handlers use a community Prometheus package on NuGet, [prometheus-net](TODO). It's a .NET Standard library, so you can use it from .NET Framework and .NET Core apps.
+> Both handlers use a community Prometheus package on NuGet, [prometheus-net](https://github.com/prometheus-net/prometheus-net). It's a .NET Standard library, so you can use it from .NET Framework and .NET Core apps.
 
 ---
 

--- a/slides/sections/metrics-dashboard.md
+++ b/slides/sections/metrics-dashboard.md
@@ -53,7 +53,7 @@ Grafana has an API you can use to automate setup, and we'll use that to build a 
 
 To make a custom Grafana image, you need to configure a data source, create users and deploy your own dashboard. The [Grafana Dockerfile](./docker/metrics-dashboard/grafana/Dockerfile) does that.
 
-It uses a [data source provisioning](TODO) and [dashboard provisioning](TODO), which is standard Grafana functionality, and the Grafana API to set up a read-only user.
+It uses a [data source provisioning](http://docs.grafana.org/administration/provisioning/#datasources) and [dashboard provisioning](http://docs.grafana.org/administration/provisioning/#dashboards), which is standard Grafana functionality, and the Grafana API to set up a read-only user.
 
 ---
 

--- a/slides/sections/metrics-dashboard.md
+++ b/slides/sections/metrics-dashboard.md
@@ -18,7 +18,7 @@ We'll do that by running Promtheus and Grafana - the leading tools in this space
 
 Prometheus is a metrics server. It runs a time-series database to store instrumentation data, polls configured endpoints to collect data, and provides an API (and a simple Web UI) to retrieve the raw or aggregated data.
 
-The Prometheus team maintain a Docker image for Linux, but we'll use a Windows Docker image from [dockersamples/aspnet-monitoring](TODO).
+The Prometheus team maintain a Docker image for Linux, but we'll use a Windows Docker image from [dockersamples/aspnet-monitoring](https://github.com/dockersamples/aspnet-monitoring).
 
 ---
 
@@ -43,7 +43,7 @@ docker image build -t dwwx/prometheus `
 
 Grafana is a dashboard server. It can connect to data sources and provide rich dashboards to show the overall health of your app. 
 
-There isn't an official Windows variant of the Grafana image, but we can use the one from [dockersamples/aspnet-monitoring](TODO). 
+There isn't an official Windows variant of the Grafana image, but we can use the one from [dockersamples/aspnet-monitoring](https://github.com/dockersamples/aspnet-monitoring). 
 
 Grafana has an API you can use to automate setup, and we'll use that to build a custom Docker image.
 

--- a/slides/sections/metrics-runtime.md
+++ b/slides/sections/metrics-runtime.md
@@ -22,7 +22,7 @@ Here's a new version of the [web application Dockerfile](./docker/metrics-runtim
 
 The utility app reads from Windows Performance Counters and publishes them as an API on port `50505`.
 
-> The web code is unchanged. The exporter comes from the [dockersamples/aspnet-monitoring](TODO) sample app.
+> The web code is unchanged. The exporter comes from the [dockersamples/aspnet-monitoring](https://github.com/dockersamples/aspnet-monitoring) sample app.
 
 ---
 

--- a/slides/sections/metrics-runtime.md
+++ b/slides/sections/metrics-runtime.md
@@ -2,7 +2,7 @@
 
 ---
 
-Containerized applications give you new opportunities for monitoring. You export metrics from each container, collect them centrally and showyour whole application health in a dashboard.
+Containerized applications give you new opportunities for monitoring. You export metrics from each container, collect them centrally and show your whole application health in a dashboard.
 
 The metrics collector and dashboard run in containers too, so now you can run the exact same metrics stack in dev that you use in production.
 

--- a/slides/sections/prod-config.md
+++ b/slides/sections/prod-config.md
@@ -14,7 +14,7 @@ We'll do this next, extending the web image to read external configuration.
 
 ---
 
-The app has a [Web.config]() file, which contains setup that will be the same in every environment, and a [log4net.config]() file and [connectionStgrings.config]() file which will change.
+The app has a [Web.config]() file, which contains setup that will be the same in every environment, and a [log4net.config]() file and [connectionStrings.config]() file which will change.
 
 The [updated Dockerfile](./docker/prod-config/signup-web/Dockerfile) sets that up using environment variables to inject a different source path for the config files.
 

--- a/slides/sections/prod-dependencies.md
+++ b/slides/sections/prod-dependencies.md
@@ -18,7 +18,7 @@ We'll add that functionality to our old ASP.NET app by packaging a dependency ch
 
 The utility is just a .NET Framework console app. It uses the same configuration structure as the ASP.NET app, so it will use the same settings as the app.
 
-In the [Program class](./src/Utilities.DependencyCheck/Program.cs) the app uses [Polly](TODO) to wrap a SQL connection check. It retries three times to connect to SQL Server, and if the third attempt fails, the utility returns an exit code of `1`.
+In the [Program class](./src/Utilities.DependencyCheck/Program.cs) the app uses [Polly](https://github.com/App-vNext/Polly) to wrap a SQL connection check. It retries three times to connect to SQL Server, and if the third attempt fails, the utility returns an exit code of `1`.
 
 ---
 

--- a/slides/sections/prod-health.md
+++ b/slides/sections/prod-health.md
@@ -24,7 +24,7 @@ In the [Program class](./src/Utilities.HealthCheck/Program.cs) the utility expec
 
 ## Packaging the health checker
 
-There's another new stage in the [updated Dockerfile](./docker/prod-health/signup-web/Dockerfile) - it builds the health check utiliuty from source. 
+There's another new stage in the [updated Dockerfile](./docker/prod-health/signup-web/Dockerfile) - it builds the health check utility from source. 
 
 Then the output is copied into the final Docker image, alongside the original ASP.NET app and the dependency checker.
 

--- a/slides/sections/swarm-services.md
+++ b/slides/sections/swarm-services.md
@@ -88,7 +88,7 @@ Some containers will be using the original definition with Nano Server, and some
 docker service ps pinger
 ```
 
-> Docker ensures new tasks are healthy before carrying on with the rollout. You have [fine control](TODO) over how the rollout happens.
+> Docker ensures new tasks are healthy before carrying on with the rollout. You have [fine control](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/) over how the rollout happens.
 
 ---
 

--- a/slides/sections/swarm-services.md
+++ b/slides/sections/swarm-services.md
@@ -94,7 +94,7 @@ docker service ps pinger
 
 ## Inspecting swarm services
 
-The service definition is stored in the swarm, securely peristeted among the manager nodes. 
+The service definition is stored in the swarm, securely persisted among the manager nodes. 
 
 _ Check the service details: _
 

--- a/slides/sections/swarm-stack.md
+++ b/slides/sections/swarm-stack.md
@@ -168,7 +168,7 @@ docker secret create `
 
 ## Check the secret object
 
-Secrets aren't secret, you cannot read the original plain text.
+Secrets are secret, you cannot read the original plain text.
 
 _ Check the secret object is stored: _
 

--- a/slides/sections/swarm-stack.md
+++ b/slides/sections/swarm-stack.md
@@ -91,7 +91,7 @@ The output will list all the nodes in the swarm. You should have one manager and
 
 You deploy apps to swarm using Docker Compose files. There are some attributes which only apply to swarm mode (like the `deploy` section), and some which are ignored in swarm mode (like `depends_on`).
 
-You can combine multiple compose files to make a single file. That's useful for keeping the core solution in one compose file like [v11-core.yml](./app/v11-cose.yml), and adding environment-specific overrides in other files like [v11-dev.yml](./app/v11-dev.yml) and [v11-prod.yml](./app/v11-prod.yml).
+You can combine multiple compose files to make a single file. That's useful for keeping the core solution in one compose file like [v11-core.yml](./app/v11-core.yml), and adding environment-specific overrides in other files like [v11-dev.yml](./app/v11-dev.yml) and [v11-prod.yml](./app/v11-prod.yml).
 
 ---
 


### PR DESCRIPTION
Fix typos + add missing links.

There are still 5 missing links, you can find them by searching for `]()` in `*.md` files.

Thanks for preparing the workshop! :)